### PR TITLE
Convert all verbs to POST

### DIFF
--- a/lib/ruby-ipfs-http-client/connection/base.rb
+++ b/lib/ruby-ipfs-http-client/connection/base.rb
@@ -13,7 +13,7 @@ module Ipfs
 
       def up?
         begin
-          HTTP.get("http://#{@host}:#{@port}#{DEFAULT_BASE_PATH}/id")
+          HTTP.post("http://#{@host}:#{@port}#{DEFAULT_BASE_PATH}/id")
           true
         rescue HTTP::ConnectionError
           false

--- a/lib/ruby-ipfs-http-client/request/basic_request.rb
+++ b/lib/ruby-ipfs-http-client/request/basic_request.rb
@@ -3,7 +3,7 @@ require_relative './request'
 module Ipfs
   class BasicRequest < Request
     def initialize(path, **arguments)
-      super(path, :get)
+      super(path, :post)
 
       @multihash = arguments[:multihash]
     end

--- a/spec/api/files/cat_spec.rb
+++ b/spec/api/files/cat_spec.rb
@@ -22,8 +22,8 @@ describe Ipfs::Command::Cat do
       expect(request.path).to eq described_class::PATH
     end
 
-    it 'has a request where the verb is GET' do
-      expect(request.verb).to eq :get
+    it 'has a request where the verb is POST' do
+      expect(request.verb).to eq :post
     end
 
     it 'has a request options containing the multihash' do

--- a/spec/api/files/ls_spec.rb
+++ b/spec/api/files/ls_spec.rb
@@ -19,8 +19,8 @@ describe Ipfs::Command::Ls do
         expect(request.path).to eq described_class::PATH
       end
 
-      it 'has a request where the verb is GET' do
-        expect(request.verb).to eq :get
+      it 'has a request where the verb is POST' do
+        expect(request.verb).to eq :post
       end
 
       it 'has a request options containing the multihash' do

--- a/spec/api/generic/id_spec.rb
+++ b/spec/api/generic/id_spec.rb
@@ -19,8 +19,8 @@ describe Ipfs::Command::Id do
       expect(request.path).to eq described_class::PATH
     end
 
-    it 'has a request where the verb is GET' do
-      expect(request.verb).to eq :get
+    it 'has a request where the verb is POST' do
+      expect(request.verb).to eq :post
     end
 
     it 'has a request without options' do

--- a/spec/api/generic/version_spec.rb
+++ b/spec/api/generic/version_spec.rb
@@ -19,8 +19,8 @@ describe Ipfs::Command::Version do
       expect(request.path).to eq described_class::PATH
     end
 
-    it 'has a request where the verb is GET' do
-      expect(request.verb).to eq :get
+    it 'has a request where the verb is POST' do
+      expect(request.verb).to eq :post
     end
 
     it 'has a request without options' do

--- a/spec/connection/default_spec.rb
+++ b/spec/connection/default_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Ipfs::Connection::Default do
   describe '#up?' do
     context 'the connection fails' do
       before do
-        stub_request(:get, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
+        stub_request(:post, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
           .to_raise HTTP::ConnectionError
       end
 
@@ -30,7 +30,7 @@ RSpec.describe Ipfs::Connection::Default do
 
     context 'the connection succeed' do
       before do
-        stub_request(:get, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
+        stub_request(:post, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
       end
 
       it 'returns true' do

--- a/spec/connection/ipfs_config_spec.rb
+++ b/spec/connection/ipfs_config_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Ipfs::Connection::IpfsConfig do
   describe '#up?' do
     context 'the connection fails' do
       before do
-        stub_request(:get, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
+        stub_request(:post, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
           .to_raise HTTP::ConnectionError
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Ipfs::Connection::IpfsConfig do
 
     context 'the connection succeed' do
       before do
-        stub_request(:get, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
+        stub_request(:post, "http://#{location[:host]}:#{location[:port]}/api/v0/id")
       end
 
       it 'returns true' do

--- a/spec/request/basic_request_spec.rb
+++ b/spec/request/basic_request_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Ipfs::BasicRequest do
   describe '#verb' do
     let(:id_request) { described_class.new id_path }
 
-    it 'gives back the GET HTTP verb' do
-      expect(id_request.verb).to eq :get
+    it 'gives back the POST HTTP verb' do
+      expect(id_request.verb).to eq :post
     end
   end
 


### PR DESCRIPTION
Based on the comments in #59, I converted all the verbs to POST. I think if the IPFS protocol no longer supports GET, then maybe we should add some error handling for users who use GET or other unsupported verbs. Thoughts?