### PR TITLE
Move http dependency to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 ruby '2.6.1'
 
-gem 'http', '~> 4.0.5'
 gem 'rake', '~> 12.3.3'
 gem 'yard', '~> 0.9.20'
 gem 'rubocop', '~> 0.65.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -30,7 +30,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     psych (3.1.0)
-    public_suffix (3.0.0)
+    public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (12.3.3)
     rspec (3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ruby-ipfs-http-client (0.5.1)
+      http (>= 4.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -71,7 +72,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  http (~> 4.0.5)
   rake (~> 12.3.3)
   rspec (~> 3.8.0)
   rubocop (~> 0.65.0)

--- a/ruby-ipfs-http-client.gemspec
+++ b/ruby-ipfs-http-client.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.required_ruby_version = '>= 2.4'
+  s.add_dependency 'http', '>= 4.0.5'
 
   s.add_development_dependency 'rspec', '~> 3.8.0'
   s.add_development_dependency 'webmock', '~>3.5.1'


### PR DESCRIPTION
This library depends on `http` gem. So it's dependency move to gemspec from Gemfile.